### PR TITLE
Two fixes made to my derivative extension

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -125,7 +125,7 @@ const NasaApodIndicator = new Lang.Class({
             this.wallpaperItem.setSensitive(!this._updatePending && this.filename != "");
         }));
 
-        this._refresh();
+        this._restartTimeout(60);
     },
 
     _setBackground: function() {
@@ -137,10 +137,10 @@ const NasaApodIndicator = new Lang.Class({
             doSetBackground(this.filename, 'org.gnome.desktop.screensaver');
     },
 
-    _restartTimeout: function() {
+    _restartTimeout: function(seconds = TIMEOUT_SECONDS) {
         if (this._timeout)
             Mainloop.source_remove(this._timeout);
-        this._timeout = Mainloop.timeout_add_seconds(TIMEOUT_SECONDS, Lang.bind(this, this._refresh));
+        this._timeout = Mainloop.timeout_add_seconds(seconds, Lang.bind(this, this._refresh));
     },
 
     _showDescription: function() {

--- a/extension.js
+++ b/extension.js
@@ -99,6 +99,7 @@ const NasaApodIndicator = new Lang.Class({
         this._timeout = null;
 
         this._settings = Utils.getSettings();
+	this.actor.visible = !this._settings.get_boolean('hide'); // set initial indicator visibility state
         this._settings.connect('changed::hide', Lang.bind(this, function() {
             this.actor.visible = !this._settings.get_boolean('hide');
         }));


### PR DESCRIPTION
I've created a derivative extension (that sets wallpaper to Bing's picture of the day - https://github.com/neffo/bing-wallpaper-gnome-extension). I made two minor fixes, so bringing them back upstream.

- Calling _refresh() in _init() may slow down Gnome-shell loading.
- Initial indicator visibility is not set correctly on startup (only on settings change)