### PR TITLE
WIP: Pick API key from pool by default

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -28,6 +28,11 @@ const RETRY_RATE_LIMIT_SECONDS = 60 * 30;
 const RETRY_NETWORK_UNAVAILABLE = 60;
 const ICON = "saturn";
 
+const DefaultApiKeys = [
+    "XKSoS8Bv05ij8JH8UWa7eqMavXgGfFStcc6Pu3KH",
+    "jCUjMOBpL523SxLoi4PogFZ3YsvvFtVNyEvRd0IB"
+]
+
 
 let nasaApodIndicator;
 let httpSession = new Soup.SessionAsync();

--- a/schemas/org.gnome.shell.extensions.nasa-apod.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.nasa-apod.gschema.xml
@@ -40,7 +40,7 @@
     </key>
 
     <key name="api-key" type="s">
-      <default>"XKSoS8Bv05ij8JH8UWa7eqMavXgGfFStcc6Pu3KH"</default>
+      <default>"[Automatic]"</default>
       <summary>NASA APOD api key.</summary>
       <description>Get your API key from https://api.nasa.gov/</description>
     </key>


### PR DESCRIPTION
As discussed in #17, I'm trying to put together a solution to cope with the number of requests on default configuration (when the user doesn't have a personal API key), by distributing the load on multiple default API keys.

I'll use this PR to ask about directions on what I'm doing (sorry not used to JS, and never worked on a gnome shell extension before)

Closes #17