### PR TITLE
Use gnome-extensions prefs to launch settings

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -34,7 +34,7 @@ Soup.Session.prototype.add_feature.call(httpSession, new Soup.ProxyResolverDefau
 
 
 function openPrefs() {
-    Util.spawn(["gnome-shell-extension-prefs", Me.metadata.uuid]);
+    Util.spawn(["gnome-extensions", "prefs", Me.metadata.uuid]);
 }
 
 function xdg_open(url) {


### PR DESCRIPTION
In Gnome 3.36 clicking "Settings" did not open preferences, creating the
following journal entry:

    This application can not open files.

In Gnome 3.36 (under Arch Linux at least) "gnome-shell-extension-prefs"
doesn't seem to open preferences of individual extensions anymore;
instead it opens the new "Extensions" app.  Passing an extension ID on
command line fails:

    $ gnome-shell-extension-prefs nasa_apod@elinvention.ovh
    (gnome-shell-extension-prefs:14409): GLib-GIO-CRITICAL **: 13:19:57.510: This application can not open files.

No window opens; the process hangs until interrupted or killed.

Gnome 3.36 offers the "gnome-extensions" tool which among other things
offers a "prefs" subcommand to open the preferences of a specific
extension, so use this tool instead to implement the "Settings" button.

I think "gnome-extensions" is already available on Gnome 3.34 which
appears to be the oldest Gnome version supported by this extensions, but
having no Gnome 3.34 installation I didn't test this.