### PR TITLE
Update metadata.json for GNOME 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "nasa_apod@elinvention.ovh",
   "name": "NASA APOD Wallpaper Changer",
   "shell-version": [
-    "43"
+    "43", "44"
   ],
   "gettext-domain": "nasa-apod",
   "settings-schema": "org.gnome.shell.extensions.nasa-apod",


### PR DESCRIPTION
With GNOME 44 being available and fedora releasing a new version, the extension no longer works. This would allow it to work for now.